### PR TITLE
Convert to ArgumentParser library

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "d2930e8fcf9c33162b9fcc1d522bc975e2d4179b",
+          "version": "1.0.1"
+        }
+      },
+      {
         "package": "Typer",
         "repositoryURL": "https://github.com/Samasaur1/Typer.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
-// swift-tools-version:4.0
-// Managed by ice
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
@@ -10,8 +10,16 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Samasaur1/Typer.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0")
     ],
     targets: [
-        .target(name: "TyperTool", dependencies: ["Typer"]),
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "TyperTool",
+            dependencies: [
+                .product(name: "Typer", package: "Typer"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ])
     ]
 )

--- a/Sources/TyperTool/Marathonfile
+++ b/Sources/TyperTool/Marathonfile
@@ -1,1 +1,0 @@
-https://github.com/Samasaur1/Typer.git

--- a/Sources/TyperTool/main.swift
+++ b/Sources/TyperTool/main.swift
@@ -48,6 +48,16 @@ extension Typer.Rate {
         }
     }
 }
+extension Typer.Rate: ExpressibleByArgument {
+    public init?(argument: String) {
+        switch argument.lowercased() {
+        case "allatonce": self = .allAtOnce
+        case "consistent": self = .consistent
+        case "natural": self = .natural
+        default: return nil
+        }
+    }
+}
 
 class UserDefaultsHelper {
     #if DEBUG
@@ -112,6 +122,14 @@ struct TyperCommand: ParsableCommand {
 //    @Argument(help: .init("The time to wait, in seconds, before starting to type", discussion: "Mutually exclusive with the `--delay` option", valueName: "delay")) var d1: Int = UserDefaultsHelper.shared.delay
 
     @Option(name: .customLong("delay"), help: .init("The time to wait, in seconds, before starting to type", valueName: "delay")) var countdown: Int = UserDefaultsHelper.shared.delay
+    @Option(help: "The rate to type at") var rate: Typer.Rate = UserDefaultsHelper.shared.rate
+//    @Flag(help: "The rate to type at") var rate: Rate = .natural
+//
+//    enum Rate: EnumerableFlag {
+//        case allAtOnce
+//        case natural
+//        case consistent
+//    }
 
     func run() throws {
 //        let countdown = delay ?? d1
@@ -122,7 +140,7 @@ struct TyperCommand: ParsableCommand {
             sleep(1)
         }
         print("Printing...")
-        Typer.type(text)
+        Typer.type(text, typing: rate)
         print("Successfully typed:")
         print(text)
     }

--- a/Sources/TyperTool/main.swift
+++ b/Sources/TyperTool/main.swift
@@ -115,25 +115,19 @@ struct TyperCommand: ParsableCommand {
         defaultSubcommand: nil,
         helpNames: .shortAndLong)
 
-    //If you want to be able to run `typer hello 5` instead of `typer hello --delay 5` and still be able to use --delay before the text, uncomment the option and argument lines below, comment out the @Option delay line on line 114, and uncomment the `let countdown` line on line 117
-
-//    @Option(help: .init("The time to wait, in seconds, before starting to type (default: \(UserDefaultsHelper.shared.delay))", discussion: "Mutually exclusive with the `<delay>` argument", valueName: "delay", shouldDisplay: true)) var delay: Int?
     @Argument(help: "The text to type", transform: { $0.replacingOccurrences(of: "\\\\", with: "\\").replacingOccurrences(of: "\\n", with: "\n").replacingOccurrences(of: "\\r", with: "\r").replacingOccurrences(of: "\\t", with: "\t")}) var text: String
-//    @Argument(help: .init("The time to wait, in seconds, before starting to type", discussion: "Mutually exclusive with the `--delay` option", valueName: "delay")) var d1: Int = UserDefaultsHelper.shared.delay
 
     @Option(name: .customLong("delay"), help: .init("The time to wait, in seconds, before starting to type", valueName: "delay")) var countdown: Int = UserDefaultsHelper.shared.delay
     @Option(help: "The rate to type at") var rate: Typer.Rate = UserDefaultsHelper.shared.rate
-//    @Flag(help: "The rate to type at") var rate: Rate = .natural
-//
-//    enum Rate: EnumerableFlag {
-//        case allAtOnce
-//        case natural
-//        case consistent
-//    }
+
+    @Flag(help: .init("Save the given delay and/or rate as future defaults", discussion: "Due to restrictions in the argument parsing library used, you must still pass some text to type — however, this text WILL NOT be typed.")) var config = false
 
     func run() throws {
-//        let countdown = delay ?? d1
-
+        if config {
+            UserDefaultsHelper.shared.delay = countdown
+            UserDefaultsHelper.shared.rate = rate
+            return
+        }
         print("Printing in...")
         for i in 0..<countdown {
             print(countdown - i)
@@ -145,5 +139,29 @@ struct TyperCommand: ParsableCommand {
         print(text)
     }
 }
+//struct TyperConfigCommand: ParsableCommand {
+//    static var configuration = CommandConfiguration(
+//        commandName: "typer-config",
+//        abstract: "Set the defaults for typing",
+//        discussion: "Currently, you can configure the delay and the rate",
+//        version: "1.0.0",
+//        shouldDisplay: true,
+//        subcommands: [],
+//        defaultSubcommand: nil,
+//        helpNames: .shortAndLong
+//    )
+//
+//    @Option(help: "The time to wait, in seconds, before starting to type") var delay: Int?
+//    @Option(help: "The rate to type at") var rate: Typer.Rate?
+//
+//    func run() throws {
+//        if let d = delay {
+//            UserDefaultsHelper.shared.delay = d
+//        }
+//        if let r = rate {
+//            UserDefaultsHelper.shared.rate = r
+//        }
+//    }
+//}
 
 TyperCommand.main()

--- a/Sources/TyperTool/main.swift
+++ b/Sources/TyperTool/main.swift
@@ -1,26 +1,131 @@
+import ArgumentParser
 import Typer
 import Foundation
 
-guard CommandLine.arguments.count > 1 else {
-    print("You must provide text to type!")
-    exit(1)
-}
-let text = CommandLine.arguments[1].replacingOccurrences(of: "\\\\", with: "\\").replacingOccurrences(of: "\\n", with: "\n").replacingOccurrences(of: "\\r", with: "\r").replacingOccurrences(of: "\\t", with: "\t")
-print("Text to print:")
-print(text)
+extension Typer.Rate {
+    struct Trate: Codable {
+        let type: Int
+        let delay: UInt32?
+        let variance: UInt32?
 
-var countdown: Int = 10
-if CommandLine.arguments.count >= 3 {
-    if let int = Int(CommandLine.arguments[2]) {
-        countdown = int
+        init(_ t: Typer.Rate) {
+            switch t {
+            case .allAtOnce:
+                type = 1
+            case .consistent:
+                type = 2
+            case .customConsistent(µsecondDelay: let d):
+                type = 3
+                delay = d
+                variance = nil
+                return
+            case let .customVarying(µsecondBaseDelay: d, maxVariance: v):
+                type = 4
+                delay = d
+                variance = v
+                return
+            case .natural:
+                type = 5
+            }
+            delay = nil
+            variance = nil
+        }
+    }
+    init(_ t: Trate) {
+        switch t.type {
+        case 1:
+            self = .allAtOnce
+        case 2:
+            self = .consistent
+        case 3:
+            self = .customConsistent(µsecondDelay: t.delay!)
+        case 4:
+            self = .customVarying(µsecondBaseDelay: t.delay!, maxVariance: t.variance!)
+        case 5:
+            self = .natural
+        default:
+            fatalError("Don't modify UserDefaults!")
+        }
     }
 }
-print("Printing in...")
-for i in 0..<countdown {
-    print(countdown - i)
-    sleep(1)
+
+class UserDefaultsHelper {
+    #if DEBUG
+    static func reset() {
+        UserDefaults.standard.removeObject(forKey: "delay")
+        UserDefaults.standard.removeObject(forKey: "rate")
+        UserDefaults.standard.removeObject(forKey: "initialized")
+        Self.shared = UserDefaultsHelper()
+    }
+    static var shared = UserDefaultsHelper()
+    #else
+    static let shared = UserDefaultsHelper()
+    #endif
+    private init() {
+        let initialized = UserDefaults.standard.bool(forKey: "initialized")
+        if initialized {
+            delay = UserDefaults.standard.integer(forKey: "delay")
+        } else {
+            delay = 10
+            UserDefaults.standard.setValue(10, forKey: "delay")
+        }
+
+        if let r = UserDefaults.standard.object(forKey: "rate") as? Data, let r2 = try? PropertyListDecoder().decode(Typer.Rate.Trate.self, from: r) {
+            rate = Typer.Rate(r2)
+        } else {
+            rate = .natural
+            UserDefaults.standard.setValue(try! PropertyListEncoder().encode(Typer.Rate.Trate(rate)), forKey: "rate")
+        }
+
+
+        UserDefaults.standard.set(true, forKey: "initialized")
+    }
+
+    var delay: Int {
+        didSet {
+            UserDefaults.standard.set(delay, forKey: "delay")
+        }
+    }
+
+    var rate: Typer.Rate {
+        didSet {
+            UserDefaults.standard.setValue(try! PropertyListEncoder().encode(Typer.Rate.Trate(rate)), forKey: "rate")
+        }
+    }
 }
-print("Printing...")
-Typer.type(text)
-print("Successfully typed:")
-print(text)
+
+struct TyperCommand: ParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "typer",
+        abstract: "Types the given text",
+        discussion: "This command types the given text at a 'natural' speed, designed to fool other software into thinking it was typed by the user",
+        version: "2.0.0",
+        shouldDisplay: true,
+        subcommands: [],
+        defaultSubcommand: nil,
+        helpNames: .shortAndLong)
+
+    //If you want to be able to run `typer hello 5` instead of `typer hello --delay 5` and still be able to use --delay before the text, uncomment the option and argument lines below, comment out the @Option delay line on line 114, and uncomment the `let countdown` line on line 117
+
+//    @Option(help: .init("The time to wait, in seconds, before starting to type (default: \(UserDefaultsHelper.shared.delay))", discussion: "Mutually exclusive with the `<delay>` argument", valueName: "delay", shouldDisplay: true)) var delay: Int?
+    @Argument(help: "The text to type", transform: { $0.replacingOccurrences(of: "\\\\", with: "\\").replacingOccurrences(of: "\\n", with: "\n").replacingOccurrences(of: "\\r", with: "\r").replacingOccurrences(of: "\\t", with: "\t")}) var text: String
+//    @Argument(help: .init("The time to wait, in seconds, before starting to type", discussion: "Mutually exclusive with the `--delay` option", valueName: "delay")) var d1: Int = UserDefaultsHelper.shared.delay
+
+    @Option(name: .customLong("delay"), help: .init("The time to wait, in seconds, before starting to type", valueName: "delay")) var countdown: Int = UserDefaultsHelper.shared.delay
+
+    func run() throws {
+//        let countdown = delay ?? d1
+
+        print("Printing in...")
+        for i in 0..<countdown {
+            print(countdown - i)
+            sleep(1)
+        }
+        print("Printing...")
+        Typer.type(text)
+        print("Successfully typed:")
+        print(text)
+    }
+}
+
+TyperCommand.main()

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,0 @@
-curl -LO https://github.com/Samasaur1/TyperTool/releases/download/v1.0.0/typer-1.0.0.zip
-unzip typer-1.0.0.zip
-mv typer /usr/local/bin/typer
-rm typer-1.0.0.zip
-clear
-echo "Successfully installed TyperTool version 1.0.0"


### PR DESCRIPTION
As of right now, the only user-level changes are that you must use the `--delay` flag when passing the delay.
There is also an undocumented feature set that allows you to set the default delay time using UserDefaults.

Technically, this does close #2, although we want a user-facing way to do this. It will also allow the changing of the typing rate (although maybe not to the custom rates), closing #1 as well.